### PR TITLE
Changed array ordering to be in line with database ids

### DIFF
--- a/src/Controllers/DocsController.php
+++ b/src/Controllers/DocsController.php
@@ -185,7 +185,7 @@ class DocsController extends BaseController
                     ]);
                 }
 
-                $docs[] = [
+                $docs[$document->id] = [
                     'id' => $document->id,
                     'name' => $document->file_name,
                     'hash' => md5($document->file_name),


### PR DESCRIPTION
I've encountered an error on my side where if I upload documents and then click on them, I either get the wrong document showing up or I get a page-not-found error message. I believe this is because the array in the getDocs() method of the DocsController is populated in alphabetical order and that this doesn't correspond to the id in the view($id) method, which comes from the document table in the database.

I have made a change to populate the array based on the order of the document ids. This change has fixed the problem on my side and I would like to ask you to review and merge it if you think I'm correct. 